### PR TITLE
fix: TypeScript v6.0 対応のため tsconfig.json を根本修正する

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,10 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
+    "moduleResolution": "node10",
     "lib": ["ESNext", "ESNext.AsyncIterable", "DOM"],
     "outDir": "./dist",
+    "rootDir": "./src",
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,
@@ -22,9 +23,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
-    "newLine": "LF"
+    "newLine": "LF",
+    "types": ["node"]
   },
-  "include": ["src/**/*"],
-  "types": ["src/types/*.d.ts"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## 概要

TypeScript v6.0 で非推奨となった tsconfig.json の設定を根本的に修正します。

Fixes #1103

## 変更内容

| 項目 | 変更前 | 変更後 | 理由 |
|------|--------|--------|------|
| `moduleResolution` | `"Node"` | `"node10"` | TypeScript v6.0 で `"Node"` は非推奨。CommonJS プロジェクトでは `"node10"` が正しい代替 |
| `rootDir` | (未設定) | `"./src"` | `outDir` 設定時には `rootDir` が必須 |
| `baseUrl` | `"."` | (削除) | `paths` なしの `baseUrl` は非推奨 |
| `types` (compilerOptions) | (未設定) | `["node"]` | 型定義のデフォルト自動ロードが変更されたため、明示的に指定 |
| `types` (トップレベル) | `["src/types/*.d.ts"]` | (削除) | tsconfig のトップレベルに `types` は無効なフィールドのため削除 |

## `moduleResolution` の選択について

issue では `"bundler"` が推奨されていますが、TypeScript の仕様上 `"bundler"` は `module` が `"commonjs"` の場合に使用できません（`TS5095` エラー）。  
本プロジェクトは CommonJS 出力を使用しているため、非推奨の `"Node"` の正しい後継である `"node10"` を採用しました。

## 確認事項

- [x] `tsc --noEmit` によるビルド確認 (エラーなし)
- [x] `yarn compile` によるコンパイル確認 (エラーなし)
